### PR TITLE
Fix compile

### DIFF
--- a/6brd.c
+++ b/6brd.c
@@ -33,6 +33,7 @@
 #include "6brd.h"
 
 struct config config = { .log_level = LOG_ERR };
+struct interface *interfaces;
 static int ioctl_sock;
 
 static int scan_args (int argc, char **argv) {

--- a/6brd.h
+++ b/6brd.h
@@ -53,7 +53,9 @@ struct config {
 	bool foreground;
 	int log_level;
 	int cnt;
-} config;
+};
+
+extern struct config config;
 
 struct interface {
 	int ifindex;
@@ -61,7 +63,9 @@ struct interface {
 	int learn_routes;
 	int external;
 	struct odhcpd_event ndp_event;
-} *interfaces;
+};
+
+extern struct interface *interfaces;
 
 // Exported main functions
 int odhcpd_register(struct odhcpd_event *event);


### PR DESCRIPTION
# Summary

Failed to complie with errors
```
➜  6brd git:(master) make
cc -pipe -g -Wall -Wextra -O2 -D_GNU_SOURCE -I/usr/include/libnl3  -c -o 6brd.o 6brd.c
6brd.c: In function ‘odhcpd_receive_packets’:
6brd.c:233:69: warning: unused parameter ‘events’ [-Wunused-parameter]
  233 | static void odhcpd_receive_packets(struct uloop_fd *u, unsigned int events)
      |                                                        ~~~~~~~~~~~~~^~~~~~
cc -pipe -g -Wall -Wextra -O2 -D_GNU_SOURCE -I/usr/include/libnl3  -c -o netlink.o netlink.c
netlink.c: In function ‘cb_rtnl_valid’:
netlink.c:105:52: warning: unused parameter ‘arg’ [-Wunused-parameter]
  105 | static int cb_rtnl_valid(struct nl_msg *msg, void *arg)
      |                                              ~~~~~~^~~
cc -pipe -g -Wall -Wextra -O2 -D_GNU_SOURCE -I/usr/include/libnl3  -c -o ndp.o ndp.c
cc -pipe -g -Wall -Wextra -O2 -D_GNU_SOURCE -I/usr/include/libnl3  -c -o nloop.o nloop.c
cc   6brd.o netlink.o ndp.o nloop.o /usr/lib/x86_64-linux-gnu/libnl-3.so   -o 6brd
/usr/bin/ld: netlink.o:/home/pcf/Repos/6brd/6brd.h:64: multiple definition of `interfaces'; 6brd.o:/home/pcf/Repos/6brd/6brd.h:64: first defined here
/usr/bin/ld: netlink.o:/home/pcf/Repos/6brd/6brd.h:56: multiple definition of `config'; 6brd.o:/home/pcf/Repos/6brd/6brd.h:56: first defined here
/usr/bin/ld: ndp.o:/home/pcf/Repos/6brd/6brd.h:56: multiple definition of `config'; 6brd.o:/home/pcf/Repos/6brd/6brd.h:56: first defined here
/usr/bin/ld: ndp.o:/home/pcf/Repos/6brd/6brd.h:64: multiple definition of `interfaces'; 6brd.o:/home/pcf/Repos/6brd/6brd.h:64: first defined here
collect2: error: ld returned 1 exit status
make: *** [<builtin>: 6brd] Error 1
```

There are 2 ways to fix it:
- Add `extern` to declare `interfaces` and `config` in `6brd.h`, and define them in `6brd.c`
- Add `-fcommon` option to makefile for old behavior

The first is better

# Test

`make` and run on my raspberry pi(as a router), ipv6 route and neigh work as expected